### PR TITLE
M1 Macでテスト実行時に発生するエラーの解消

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem 'capybara'
   gem 'selenium-webdriver'
-  gem 'webdrivers'
+  gem 'webdrivers', '~> 5.2'
 end
 
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.3)
+    nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -239,10 +239,11 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.1.0)
+    selenium-webdriver (4.5.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     smart_properties (1.17.0)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
@@ -271,10 +272,11 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.0.0)
+    webdrivers (5.2.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
### 実行環境
- MacBook Pro (16インチ 、2021）
- macOS Monterey 12.6.1
- Apple M1 Proチップ
- Ruby 3.1.1
### エラー内容
環境構築後、`bin/rails test:all`を実行すると以下エラーが発生する
```
Webdrivers::NetworkError:
  Net::HTTPServerException: 404 "Not Found" with https://chromedriver.storage.googleapis.com/106.0.5249.61/chromedriver_mac64_m1.zip
```
### 原因
Chromedriverの命名規則が変わった影響とのこと
https://github.com/titusfortner/webdrivers/issues/237
### 解決策
- webdrivers gemを5.2.0以上にアップデートする
`$ bundle update webdrivers`
- Gemfileのwebdriversのバージョンを5.2以上に指定

※@JunichiIto さんのQiita記事を参照
https://qiita.com/jnchito/items/ef384a39cb063b0af463
### エラーログ
```
inoway@PM-QTQ46XWVVX haunted-blog % bin/rails test:all
/Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/webdrivers-5.0.0/lib/webdrivers/network.rb:19:in `get': Net::HTTPServerException: 404 "Not Found" with https://chromedriver.storage.googleapis.com/107.0.5304.62/chromedriver_mac64_m1.zip (Webdrivers::NetworkError)
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/webdrivers-5.0.0/lib/webdrivers/system.rb:74:in `block (2 levels) in download_file'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/3.1.0/tempfile.rb:317:in `open'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/webdrivers-5.0.0/lib/webdrivers/system.rb:73:in `block in download_file'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/webdrivers-5.0.0/lib/webdrivers/system.rb:72:in `chdir'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/webdrivers-5.0.0/lib/webdrivers/system.rb:72:in `download_file'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/webdrivers-5.0.0/lib/webdrivers/system.rb:63:in `download'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/webdrivers-5.0.0/lib/webdrivers/common.rb:98:in `update'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/webdrivers-5.0.0/lib/webdrivers/chromedriver.rb:149:in `block in <main>'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/actionpack-7.0.2.3/lib/action_dispatch/system_testing/browser.rb:36:in `preload'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/actionpack-7.0.2.3/lib/action_dispatch/system_testing/driver.rb:27:in `initialize'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/actionpack-7.0.2.3/lib/action_dispatch/system_test_case.rb:159:in `new'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/actionpack-7.0.2.3/lib/action_dispatch/system_test_case.rb:159:in `driven_by'
        from /Users/inoway/Workspace/haunted-blog/test/application_system_test_case.rb:6:in `<class:ApplicationSystemTestCase>'
        from /Users/inoway/Workspace/haunted-blog/test/application_system_test_case.rb:5:in `<main>'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
        from /Users/inoway/Workspace/haunted-blog/test/system/blogs_test.rb:3:in `<main>'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-7.0.2.3/lib/rails/test_unit/runner.rb:47:in `block in load_tests'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-7.0.2.3/lib/rails/test_unit/runner.rb:47:in `each'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-7.0.2.3/lib/rails/test_unit/runner.rb:47:in `load_tests'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-7.0.2.3/lib/rails/test_unit/runner.rb:40:in `run'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-7.0.2.3/lib/rails/commands/test/test_command.rb:33:in `perform'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-7.0.2.3/lib/rails/command/base.rb:87:in `perform'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-7.0.2.3/lib/rails/command.rb:48:in `invoke'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-7.0.2.3/lib/rails/commands.rb:18:in `<main>'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from bin/rails:4:in `<main>'
inoway@PM-QTQ46XWVVX haunted-blog % ruby -v
ruby 3.1.1p18 (2022-02-18 revision 53f5fc4236) [arm64-darwin21]
inoway@PM-QTQ46XWVVX haunted-blog % bin/rails test:all
/Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/webdrivers-5.0.0/lib/webdrivers/network.rb:19:in `get': Net::HTTPServerException: 404 "Not Found" with https://chromedriver.storage.googleapis.com/107.0.5304.62/chromedriver_mac64_m1.zip (Webdrivers::NetworkError)
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/webdrivers-5.0.0/lib/webdrivers/system.rb:74:in `block (2 levels) in download_file'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/3.1.0/tempfile.rb:317:in `open'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/webdrivers-5.0.0/lib/webdrivers/system.rb:73:in `block in download_file'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/webdrivers-5.0.0/lib/webdrivers/system.rb:72:in `chdir'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/webdrivers-5.0.0/lib/webdrivers/system.rb:72:in `download_file'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/webdrivers-5.0.0/lib/webdrivers/system.rb:63:in `download'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/webdrivers-5.0.0/lib/webdrivers/common.rb:98:in `update'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/webdrivers-5.0.0/lib/webdrivers/chromedriver.rb:149:in `block in <main>'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/actionpack-7.0.2.3/lib/action_dispatch/system_testing/browser.rb:36:in `preload'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/actionpack-7.0.2.3/lib/action_dispatch/system_testing/driver.rb:27:in `initialize'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/actionpack-7.0.2.3/lib/action_dispatch/system_test_case.rb:159:in `new'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/actionpack-7.0.2.3/lib/action_dispatch/system_test_case.rb:159:in `driven_by'
        from /Users/inoway/Workspace/haunted-blog/test/application_system_test_case.rb:6:in `<class:ApplicationSystemTestCase>'
        from /Users/inoway/Workspace/haunted-blog/test/application_system_test_case.rb:5:in `<main>'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
        from /Users/inoway/Workspace/haunted-blog/test/system/blogs_test.rb:3:in `<main>'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-7.0.2.3/lib/rails/test_unit/runner.rb:47:in `block in load_tests'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-7.0.2.3/lib/rails/test_unit/runner.rb:47:in `each'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-7.0.2.3/lib/rails/test_unit/runner.rb:47:in `load_tests'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-7.0.2.3/lib/rails/test_unit/runner.rb:40:in `run'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-7.0.2.3/lib/rails/commands/test/test_command.rb:33:in `perform'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-7.0.2.3/lib/rails/command/base.rb:87:in `perform'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-7.0.2.3/lib/rails/command.rb:48:in `invoke'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-7.0.2.3/lib/rails/commands.rb:18:in `<main>'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from /Users/inoway/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from bin/rails:4:in `<main>'
```